### PR TITLE
CMParts: Use NotificationManager to figure out LED capabilities

### DIFF
--- a/src/org/cyanogenmod/cmparts/notificationlight/ApplicationLightPreference.java
+++ b/src/org/cyanogenmod/cmparts/notificationlight/ApplicationLightPreference.java
@@ -18,6 +18,7 @@ package org.cyanogenmod.cmparts.notificationlight;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
+import android.app.NotificationManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.drawable.ShapeDrawable;
@@ -63,8 +64,8 @@ public class ApplicationLightPreference extends CustomDialogPreference<LightSett
      */
     public ApplicationLightPreference(Context context, AttributeSet attrs) {
         this(context, attrs, DEFAULT_COLOR, DEFAULT_TIME, DEFAULT_TIME,
-                context.getResources().getBoolean(
-                com.android.internal.R.bool.config_ledCanPulse));
+                context.getSystemService(NotificationManager.class)
+                        .doLightsSupport(NotificationManager.LIGHTS_PULSATING_LED));
     }
 
     /**
@@ -75,8 +76,9 @@ public class ApplicationLightPreference extends CustomDialogPreference<LightSett
      */
     public ApplicationLightPreference(Context context, AttributeSet attrs,
                                       int color, int onValue, int offValue) {
-        this(context, attrs, color, onValue, offValue, context.getResources().getBoolean(
-                com.android.internal.R.bool.config_ledCanPulse));
+        this(context, attrs, color, onValue, offValue,
+                context.getSystemService(NotificationManager.class)
+                        .doLightsSupport(NotificationManager.LIGHTS_PULSATING_LED));
     }
 
     /**
@@ -121,7 +123,8 @@ public class ApplicationLightPreference extends CustomDialogPreference<LightSett
         TextView tView = (TextView) holder.findViewById(android.R.id.summary);
         tView.setVisibility(View.GONE);
 
-        if (!getContext().getResources().getBoolean(com.android.internal.R.bool.config_multiColorNotificationLed)) {
+        final NotificationManager nm = getContext().getSystemService(NotificationManager.class);
+        if (!nm.doLightsSupport(NotificationManager.LIGHTS_RGB_NOTIFICATION_LED)) {
             mLightColorView.setVisibility(View.GONE);
         }
 

--- a/src/org/cyanogenmod/cmparts/notificationlight/BatteryLightSettings.java
+++ b/src/org/cyanogenmod/cmparts/notificationlight/BatteryLightSettings.java
@@ -16,6 +16,7 @@
 
 package org.cyanogenmod.cmparts.notificationlight;
 
+import android.app.NotificationManager;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.res.Resources;
@@ -66,13 +67,15 @@ public class BatteryLightSettings extends SettingsPreferenceFragment implements
         mLightEnabledPref = (CMSystemSettingSwitchPreference) prefSet.findPreference(LIGHT_ENABLED_PREF);
         mPulseEnabledPref = (CMSystemSettingSwitchPreference) prefSet.findPreference(PULSE_ENABLED_PREF);
 
-        if (!getResources().getBoolean(com.android.internal.R.bool.config_ledCanPulse) ||
-                getResources().getBoolean(org.cyanogenmod.platform.internal.R.bool.config_useSegmentedBatteryLed)) {
+        final NotificationManager nm = getContext().getSystemService(NotificationManager.class);
+
+        if (!nm.doLightsSupport(NotificationManager.LIGHTS_PULSATING_LED) ||
+                nm.doLightsSupport(NotificationManager.LIGHTS_SEGMENTED_BATTERY_LED)) {
             mGeneralPrefs.removePreference(mPulseEnabledPref);
         }
 
-        // Does the Device support changing battery LED colors?
-        if (getResources().getBoolean(com.android.internal.R.bool.config_multiColorBatteryLed)) {
+        // Does the device support changing battery LED colors?
+        if (nm.doLightsSupport(NotificationManager.LIGHTS_RGB_BATTERY_LED)) {
             setHasOptionsMenu(true);
 
             // Low, Medium and full color preferences
@@ -141,8 +144,8 @@ public class BatteryLightSettings extends SettingsPreferenceFragment implements
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        if (getResources().getBoolean(
-                com.android.internal.R.bool.config_multiColorBatteryLed)) {
+        final NotificationManager nm = getContext().getSystemService(NotificationManager.class);
+        if (nm.doLightsSupport(NotificationManager.LIGHTS_RGB_BATTERY_LED)) {
             menu.add(0, MENU_RESET, 0, R.string.reset)
                     .setIcon(R.drawable.ic_settings_backup_restore)
                     .setAlphabeticShortcut('r')

--- a/src/org/cyanogenmod/cmparts/notificationlight/LightSettingsDialog.java
+++ b/src/org/cyanogenmod/cmparts/notificationlight/LightSettingsDialog.java
@@ -170,8 +170,8 @@ public class LightSettingsDialog extends AlertDialog implements
         setView(layout);
         setTitle(R.string.edit_light_settings);
 
-        if (!getContext().getResources().getBoolean(
-                com.android.internal.R.bool.config_multiColorNotificationLed)) {
+        if (!mNotificationManager.doLightsSupport(
+                NotificationManager.LIGHTS_RGB_NOTIFICATION_LED)) {
             mColorPicker.setVisibility(View.GONE);
             mColorPanel.setVisibility(View.GONE);
             mLightsDialogDivider.setVisibility(View.GONE);

--- a/src/org/cyanogenmod/cmparts/notificationlight/NotificationLightSettings.java
+++ b/src/org/cyanogenmod/cmparts/notificationlight/NotificationLightSettings.java
@@ -18,6 +18,7 @@ package org.cyanogenmod.cmparts.notificationlight;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
+import android.app.NotificationManager;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -110,9 +111,9 @@ public class NotificationLightSettings extends SettingsPreferenceFragment implem
         mDefaultLedOff = resources.getInteger(
                 com.android.internal.R.integer.config_defaultNotificationLedOff);
 
-        mLedCanPulse = resources.getBoolean(com.android.internal.R.bool.config_ledCanPulse);
-        mMultiColorLed = resources.getBoolean(
-                com.android.internal.R.bool.config_multiColorNotificationLed);
+        final NotificationManager nm = getContext().getSystemService(NotificationManager.class);
+        mLedCanPulse = nm.doLightsSupport(NotificationManager.LIGHTS_PULSATING_LED);
+        mMultiColorLed = nm.doLightsSupport(NotificationManager.LIGHTS_RGB_NOTIFICATION_LED);
 
         mEnabledPref = (SystemSettingSwitchPreference)
                 findPreference(Settings.System.NOTIFICATION_LIGHT_PULSE);
@@ -133,14 +134,13 @@ public class NotificationLightSettings extends SettingsPreferenceFragment implem
         mScreenOnLightsPref.setOnPreferenceChangeListener(this);
         mCustomEnabledPref = (CMSystemSettingSwitchPreference)
                 findPreference(CMSettings.System.NOTIFICATION_LIGHT_PULSE_CUSTOM_ENABLE);
-        if (!resources.getBoolean(
-                org.cyanogenmod.platform.internal.R.bool.config_adjustableNotificationLedBrightness)) {
+        if (!nm.doLightsSupport(
+                NotificationManager.LIGHTS_ADJUSTABLE_NOTIFICATION_LED_BRIGHTNESS)) {
             mAdvancedPrefs.removePreference(mNotificationLedBrightnessPref);
         } else {
             mNotificationLedBrightnessPref.setOnPreferenceChangeListener(this);
         }
-        if (!resources.getBoolean(
-                org.cyanogenmod.platform.internal.R.bool.config_multipleNotificationLeds)) {
+        if (!nm.doLightsSupport(NotificationManager.LIGHTS_MULTIPLE_NOTIFICATION_LED)) {
             mAdvancedPrefs.removePreference(mMultipleLedsEnabledPref);
         } else {
             mMultipleLedsEnabledPref.setOnPreferenceChangeListener(this);


### PR DESCRIPTION
As of f/b change I7d627914b058861048071fc15776031c4152157f, there's
a more generic helper method in the notification service to get a
more unified (and extensible) list of what the on-device LEDs can
do. Move away from direct usage of the boolean resources.

Change-Id: Ib9a6f28dc52af722dac168ec219b790ad94d6a19