### PR TITLE
CMParts: Properly remove perf profile category if unsupported

### DIFF
--- a/src/org/cyanogenmod/cmparts/power/PerfProfileSettings.java
+++ b/src/org/cyanogenmod/cmparts/power/PerfProfileSettings.java
@@ -49,7 +49,7 @@ import cyanogenmod.providers.CMSettings;
 public class PerfProfileSettings extends SettingsPreferenceFragment
         implements Preference.OnPreferenceChangeListener {
 
-    private static final String KEY_PERF_PROFILE     = "perf_profile";
+    private static final String KEY_PERF_PROFILE_CATEGORY = "perf_profile_category";
     private static final String KEY_AUTO_POWER_SAVE  = "auto_power_save";
     private static final String KEY_POWER_SAVE       = "power_save";
     private static final String KEY_PER_APP_PROFILES = "app_perf_profiles";
@@ -96,8 +96,7 @@ public class PerfProfileSettings extends SettingsPreferenceFragment
         int count = mProfiles.size();
 
         if (count == 0) {
-            removePreference(KEY_PER_APP_PROFILES);
-            removePreference(KEY_PERF_SEEKBAR);
+            removePreference(KEY_PERF_PROFILE_CATEGORY);
             mPerfSeekBar = null;
             mPerAppProfilesPref = null;
 


### PR DESCRIPTION
Currently, we are attempting to find the perf profile preferences
from the preference screen. Unfortunately, this wouldn't work
since the perf profile preferences are the children of a
preference category under the preference screen.

As a result, devices without perf profile support will display
invalid seekbars and switches.

To properly remove the perf profile preferences, simply remove
the entire perf profile category. This will take care of removing
the children perf profile preferences as well.

Change-Id: Iab16234e7b683d26284f22b796a936713c39a9ae